### PR TITLE
return 422 status code when media file is not supported

### DIFF
--- a/app/controllers/api/v2/media_controller.rb
+++ b/app/controllers/api/v2/media_controller.rb
@@ -2,7 +2,13 @@
 
 class Api::V2::MediaController < Api::V1::MediaController
   def create
+    unless supported_mime_type?(params["file"].content_type)
+      render json: file_type_error, status: 415
+      return
+    end
+
     @media_attachment = current_account.media_attachments.create!(media_and_delay_params)
+
     render json: @media_attachment, serializer: REST::MediaAttachmentSerializer, status: status_from_media_processing
   rescue Paperclip::Errors::NotIdentifiedByImageMagickError
     render json: file_type_error, status: 422
@@ -19,5 +25,11 @@ class Api::V2::MediaController < Api::V1::MediaController
 
   def status_from_media_processing
     @media_attachment.not_processed? ? 202 : 200
+  end
+
+  def supported_mime_type?(content_type)
+    MediaAttachment::VIDEO_MIME_TYPES.include?(content_type) ||
+      MediaAttachment::AUDIO_MIME_TYPES.include?(content_type) ||
+      MediaAttachment::IMAGE_MIME_TYPES.include?(content_type)
   end
 end

--- a/spec/requests/api/v2/media_spec.rb
+++ b/spec/requests/api/v2/media_spec.rb
@@ -65,6 +65,21 @@ RSpec.describe 'Media API', :attachment_processing do
       end
     end
 
+    describe 'when media file is not supported' do
+      let(:params)            { { file: fixture_file_upload('attachment.not_supported_type', 'video/not_supported_type') } }
+
+      before do
+        allow(User).to receive(:find).with(token.resource_owner_id).and_return(user)
+      end
+
+      it 'returns http unsupported media type' do
+        post '/api/v2/media', headers: headers, params: params
+
+        expect(response)
+          .to have_http_status(415)
+      end
+    end
+
     describe 'when paperclip errors occur' do
       let(:media_attachments) { double }
       let(:params)            { { file: fixture_file_upload('attachment.jpg', 'image/jpeg') } }


### PR DESCRIPTION
I decided to return 415 when the MIME type isn't supported. In contrast to 422 which is used when the file is usually invalid.
Added a test for this