### PR TITLE
Very long image break the Web UI #31711

### DIFF
--- a/app/javascript/mastodon/components/media_gallery.jsx
+++ b/app/javascript/mastodon/components/media_gallery.jsx
@@ -96,6 +96,7 @@ class Item extends PureComponent {
     if (size === 4 || (size === 3 && index > 0)) {
       height = 50;
     }
+    let isNeedScrolll = false;
 
     const description = attachment.getIn(['translation', 'description']) || attachment.get('description');
 
@@ -118,6 +119,7 @@ class Item extends PureComponent {
     } else if (attachment.get('type') === 'image') {
       const previewUrl   = attachment.get('preview_url');
       const previewWidth = attachment.getIn(['meta', 'small', 'width']);
+      const originalHeight = attachment.getIn(['meta', 'original', 'height']);
 
       const originalUrl   = attachment.get('url');
       const originalWidth = attachment.getIn(['meta', 'original', 'width']);
@@ -131,6 +133,9 @@ class Item extends PureComponent {
       const focusY = attachment.getIn(['meta', 'focus', 'y']) || 0;
       const x      = ((focusX /  2) + .5) * 100;
       const y      = ((focusY / -2) + .5) * 100;
+      if (originalHeight > 600) {
+        isNeedScrolll = true;
+      }
 
       thumbnail = (
         <a
@@ -139,6 +144,9 @@ class Item extends PureComponent {
           onClick={this.handleClick}
           target='_blank'
           rel='noopener noreferrer'
+          style={{
+            height: originalHeight,
+          }}
         >
           <img
             src={previewUrl}
@@ -185,7 +193,10 @@ class Item extends PureComponent {
     }
 
     return (
-      <div className={classNames('media-gallery__item', { standalone, 'media-gallery__item--tall': height === 100, 'media-gallery__item--wide': width === 100 })} key={attachment.get('id')}>
+      <div className={classNames('media-gallery__item', { standalone, 'media-gallery__item--tall': height === 100, 'media-gallery__item--wide': width === 100 })} key={attachment.get('id')} style={{
+        overflowY: isNeedScrolll ? 'auto' : 'hidden',
+        height: 600,
+      }}>
         <Blurhash
           hash={attachment.get('blurhash')}
           dummy={!useBlurhash}

--- a/app/javascript/mastodon/components/media_gallery.jsx
+++ b/app/javascript/mastodon/components/media_gallery.jsx
@@ -96,7 +96,8 @@ class Item extends PureComponent {
     if (size === 4 || (size === 3 && index > 0)) {
       height = 50;
     }
-    let isNeedScrolll = false;
+
+    let isNeededScroll = false;
 
     const description = attachment.getIn(['translation', 'description']) || attachment.get('description');
 
@@ -119,10 +120,11 @@ class Item extends PureComponent {
     } else if (attachment.get('type') === 'image') {
       const previewUrl   = attachment.get('preview_url');
       const previewWidth = attachment.getIn(['meta', 'small', 'width']);
-      const originalHeight = attachment.getIn(['meta', 'original', 'height']);
 
       const originalUrl   = attachment.get('url');
       const originalWidth = attachment.getIn(['meta', 'original', 'width']);
+      const originalHeight = attachment.getIn(['meta', 'original', 'height']);
+
 
       const hasSize = typeof originalWidth === 'number' && typeof previewWidth === 'number';
 
@@ -133,8 +135,9 @@ class Item extends PureComponent {
       const focusY = attachment.getIn(['meta', 'focus', 'y']) || 0;
       const x      = ((focusX /  2) + .5) * 100;
       const y      = ((focusY / -2) + .5) * 100;
+
       if (originalHeight > 600) {
-        isNeedScrolll = true;
+        isNeededScroll = true;
       }
 
       thumbnail = (
@@ -194,8 +197,8 @@ class Item extends PureComponent {
 
     return (
       <div className={classNames('media-gallery__item', { standalone, 'media-gallery__item--tall': height === 100, 'media-gallery__item--wide': width === 100 })} key={attachment.get('id')} style={{
-        overflowY: isNeedScrolll ? 'auto' : 'hidden',
-        height: 600,
+        overflowY: isNeededScroll ? 'auto' : 'hidden',
+        height: 600
       }}>
         <Blurhash
           hash={attachment.get('blurhash')}
@@ -308,12 +311,18 @@ class MediaGallery extends PureComponent {
 
     let children, spoilerButton;
 
-    const style = {};
+    let style = {};
 
     if (this.isFullSizeEligible()) {
       style.aspectRatio = `${this.props.media.getIn([0, 'meta', 'small', 'aspect'])}`;
     } else {
       style.aspectRatio = '3 / 2';
+    }
+
+    const originalHeight = media.get(0).getIn(['meta', 'original', 'height']);
+
+    if (originalHeight > 600) {
+      style = {};
     }
 
     const size     = media.size;

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -6916,15 +6916,12 @@ a.status-card {
 
 .media-gallery__item-thumbnail {
   cursor: pointer;
-  display: block;
   text-decoration: none;
   color: $secondary-text-color;
   position: relative;
-  z-index: -1;
 
   &,
   img {
-    height: 100%;
     width: 100%;
   }
 


### PR DESCRIPTION
### Description
[Issue](https://github.com/mastodon/mastodon/issues/31711)
When a large in height image is published it breaks the UI, stretching the web page as long as the image is.
Impeding users to interact with the footer buttons until they scroll down

## How this solves the issue
**Removing height 100% from the component Scss class**
The problem was that the height was set to be 100% so it will take as long as the image is.
**Setting a validator for if scrolling is necessary:**
We set a validator for the height, if the image is longer than 600 then place this image inside a new container in which we will have a scroll, in case we need to move along the image.
In this way users can reach the comment section without having to scroll all the way to the bottom.
 
