### PR TITLE
Fix follow request counter is a protected branch

### DIFF
--- a/app/controllers/api/v1/follow_requests_controller.rb
+++ b/app/controllers/api/v1/follow_requests_controller.rb
@@ -41,13 +41,24 @@ class Api::V1::FollowRequestsController < Api::BaseController
   end
 
   def paginated_follow_requests
-    FollowRequest.where(target_account: current_account).paginate_by_max_id(
+    FollowRequest.where(target_account: current_account, viewed: false).paginate_by_max_id(
       limit_param(DEFAULT_ACCOUNTS_LIMIT),
       params[:max_id],
       params[:since_id]
     )
   end
 
+  def mark_as_viewed
+    follow_request = FollowRequest.find_by(id: params[:id], target_account: current_account)
+
+    if follow_request
+      follow_request.update(viewed: true)
+      render json: { message: 'Follow request marked as viewed' }, status: :ok
+    else
+      render json: { error: 'Follow request not found' }, status: :not_found
+    end
+  end
+  
   def next_path
     api_v1_follow_requests_url pagination_params(max_id: pagination_max_id) if records_continue?
   end

--- a/app/javascript/mastodon/actions/accounts.js
+++ b/app/javascript/mastodon/actions/accounts.js
@@ -500,10 +500,16 @@ export function fetchFollowRequests() {
   return (dispatch) => {
     dispatch(fetchFollowRequestsRequest());
 
-    api().get('/api/v1/follow_requests').then(response => {
+    api().get('/api/v1/follow_requests?viewed=false').then(response => {
       const next = getLinks(response).refs.find(link => link.rel === 'next');
       dispatch(importFetchedAccounts(response.data));
       dispatch(fetchFollowRequestsSuccess(response.data, next ? next.uri : null));
+
+      // Marcar como vistas las solicitudes obtenidas
+      response.data.forEach(request => {
+        api().patch(`/api/v1/follow_requests/${request.id}/mark_as_viewed`);
+      });
+      
     }).catch(error => dispatch(fetchFollowRequestsFail(error)));
   };
 }

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -482,6 +482,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_04_082851) do
     t.index ["account_id"], name: "index_follow_recommendation_suppressions_on_account_id", unique: true
   end
 
+  #Añadir viewed default false, a traves de la migración AddViewedToFollowRequests
   create_table "follow_requests", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false

--- a/db/seeds/04_admin.rb
+++ b/db/seeds/04_admin.rb
@@ -10,4 +10,67 @@ if Rails.env.development?
   user = User.where(email: "admin@#{domain}").first_or_initialize(email: "admin@#{domain}", password: 'mastodonadmin', password_confirmation: 'mastodonadmin', confirmed_at: Time.now.utc, role: UserRole.find_by(name: 'Owner'), account: admin, agreement: true, approved: true)
   user.save!
   user.approve!
+
+  classic_user = Account.where(username: 'user').first_or_initialize(username: 'user')
+  classic_user.save(validate: false)
+
+  user1 = User.where(email: "user@#{domain}").first_or_initialize(email: "user@#{domain}", password: 'mastodonuser', password_confirmation: 'mastodonuser', confirmed_at: Time.now.utc, account: classic_user, agreement: true, approved: true)
+  user1.save!
+  user1.approve!
+
+
+user_account1 = Account.where(username: 'user1').first_or_initialize(username: 'user1')
+user_account1.save(validate: false)
+
+user1 = User.where(email: "user1@#{domain}").first_or_initialize(
+  email: "user1@#{domain}",
+  password: 'user1password',
+  password_confirmation: 'user1password',
+  confirmed_at: Time.now.utc,
+  account: classic_user,
+  agreement: true,
+  approved: true
+)
+user1.save!
+user1.approve!
+
+
+user_account2 = Account.where(username: 'user2').first_or_initialize(username: 'user2')
+user_account2.save(validate: false)
+
+user2 = User.where(email: "user2@#{domain}").first_or_initialize(
+  email: "user2@#{domain}",
+  password: 'user2password',
+  password_confirmation: 'user2password',
+  confirmed_at: Time.now.utc,
+  account: classic_user,
+  agreement: true,
+  approved: true
+)
+user2.save!
+user2.approve!
+
+user_account3 = Account.where(username: 'user3').first_or_initialize(username: 'user3')
+user_account3.save(validate: false)
+
+user3 = User.where(email: "user3@#{domain}").first_or_initialize(
+  email: "user3@#{domain}",
+  password: 'user3password',
+  password_confirmation: 'user3password',
+  confirmed_at: Time.now.utc,
+  account: classic_user,
+  agreement: true,
+  approved: true
+)
+user3.save!
+user3.approve!
+
+
+  mod_user_account = Account.where(username: 'moderator').first_or_initialize(username: 'moderator')
+  mod_user_account.save(validate: false)
+
+  mod_user1 = User.where(email: "moderator@#{domain}").first_or_initialize(email: "moderator@#{domain}", password: 'moderator', password_confirmation: 'moderator', confirmed_at: Time.now.utc,role: UserRole.find_by(name: 'Moderator'), account: mod_user_account, agreement: true, approved: true)
+  mod_user1.save!
+  mod_user1.approve!
+
 end


### PR DESCRIPTION
Este cambio añade un nuevo campo viewed a la tabla follow_request, que permite identificar si una solicitud de seguimiento ha sido vista o no. Posteriormente, se ha integrado este campo en el flujo de trabajo del sistema, asegurando que el contador de solicitudes de seguimiento en el frontend solo tenga en cuenta las solicitudes que no han sido vistas.